### PR TITLE
Updated Void download from 20190217 to 20190526

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LNCR_EXE=Void.exe
 
 DLR=curl
 DLR_FLAGS=-L
-BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190217/void-x86_64-ROOTFS-20190217.tar.xz
+BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
 LNCR_ZIP_EXE=Void.exe
 


### PR DESCRIPTION
I have updated the void download, because xbps-install now works behind a proxy see
https://github.com/void-linux/xbps/issues/75