### PR TITLE
Simpler, less chatty Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
 - sudo apt-get update -qq
 - sudo apt-get install make curl bsdtar check -qq
 script:
-- make
+- env LANG=en_US.UTF-8 make
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: required
-dist: xenial
+dist: disco
 language: bash
 before_script:
 - sudo apt-get update -qq
-- sudo apt-get install make curl zip unzip check -qq
+- sudo apt-get install make curl bsdtar check -qq
 script:
 - make
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 TAR=bsdtar
 
-OUT_ZIP=Void.zip
-
 # WARNING: the 20191109 snapshot is broken and fails to update:
 #
 # sudo chroot rootfs /sbin/xbps-install --sync --update --yes xbps
@@ -17,13 +15,13 @@ OUT_ZIP=Void.zip
 BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
 
-all: $(OUT_ZIP)
+all: Void.zip
 
-zip: $(OUT_ZIP)
+zip: Void.zip
 
-$(OUT_ZIP): Void.exe rootfs.tar.gz
-	@echo -e '\e[1;31mBuilding $(OUT_ZIP)\e[m'
-	$(TAR) -caf $(OUT_ZIP) Void.exe rootfs.tar.gz
+Void.zip: Void.exe rootfs.tar.gz
+	@echo -e '\e[1;31mBuilding Void.zip\e[m'
+	$(TAR) -caf Void.zip Void.exe rootfs.tar.gz
 
 Void.exe: icons.zip
 	@echo -e '\e[1;31mExtracting Void.exe...\e[m'
@@ -54,7 +52,7 @@ base.tar.xz:
 
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'
-	rm -f ${OUT_ZIP}
+	rm -f Void.zip
 	rm -f Void.exe
 	rm -f icons.zip
 	rm -f rootfs.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ clean:
 	-rm icons.zip
 	-rm rootfs.tar.gz
 	-sudo rm -r rootfs
-	-rm base.tar.gz
+	-rm base.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 OUT_ZIP=Void.zip
 LNCR_EXE=Void.exe
 
-DLR=curl
-DLR_FLAGS=-L
 BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
 LNCR_ZIP_EXE=Void.exe
@@ -28,7 +26,7 @@ Launcher.exe: icons.zip
 
 icons.zip:
 	@echo -e '\e[1;31mDownloading icons.zip...\e[m'
-	$(DLR) $(DLR_FLAGS) $(LNCR_ZIP_URL) -o icons.zip
+	curl -LSfs $(LNCR_ZIP_URL) -o icons.zip
 
 rootfs.tar.gz: rootfs
 	@echo -e '\e[1;31mBuilding rootfs.tar.gz...\e[m'
@@ -47,7 +45,7 @@ rootfs: base.tar.xz
 
 base.tar.xz:
 	@echo -e '\e[1;31mDownloading base.tar.xz...\e[m'
-	$(DLR) $(DLR_FLAGS) $(BASE_URL) -o base.tar.xz
+	curl -LSfs $(BASE_URL) -o base.tar.xz
 
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ Void.exe: icons.zip
 
 icons.zip:
 	@echo -e '\e[1;31mDownloading icons.zip...\e[m'
-	curl -LSfs $(LNCR_ZIP_URL) -o icons.zip
+	curl -LSfs -o icons.zip $(LNCR_ZIP_URL)
 
 rootfs.tar.gz: rootfs
 	@echo -e '\e[1;31mBuilding rootfs.tar.gz...\e[m'
@@ -37,7 +37,7 @@ rootfs: base.tar.xz
 
 base.tar.xz:
 	@echo -e '\e[1;31mDownloading base.tar.xz...\e[m'
-	curl -LSfs $(BASE_URL) -o base.tar.xz
+	curl -LSfs -o base.tar.xz $(BASE_URL)
 
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,13 @@ LNCR_ZIP_EXE=Void.exe
 all: $(OUT_ZIP)
 
 zip: $(OUT_ZIP)
-$(OUT_ZIP): ziproot
-	@echo -e '\e[1;31mBuilding $(OUT_ZIP)\e[m'
-	cd ziproot; zip ../$(OUT_ZIP) *
 
-ziproot: Launcher.exe rootfs.tar.gz
-	@echo -e '\e[1;31mBuilding ziproot...\e[m'
-	mkdir ziproot
-	cp Launcher.exe ziproot/${LNCR_EXE}
-	cp rootfs.tar.gz ziproot/
+$(OUT_ZIP): $(LNCR_EXE) rootfs.tar.gz
+	@echo -e '\e[1;31mBuilding $(OUT_ZIP)\e[m'
+	zip $(OUT_ZIP) $(LNCR_EXE) rootfs.tar.gz
+
+$(LNCR_EXE): Launcher.exe
+	cp Launcher.exe $(LNCR_EXE)
 
 exe: Launcher.exe
 Launcher.exe: icons.zip
@@ -50,7 +48,6 @@ base.tar.xz:
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'
 	rm -f ${OUT_ZIP}
-	rm -fr ziproot
 	rm -f Launcher.exe
 	rm -f icons.zip
 	rm -f rootfs.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TAR=bsdtar
+
 OUT_ZIP=Void.zip
 
 BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
@@ -9,11 +11,11 @@ zip: $(OUT_ZIP)
 
 $(OUT_ZIP): Void.exe rootfs.tar.gz
 	@echo -e '\e[1;31mBuilding $(OUT_ZIP)\e[m'
-	zip $(OUT_ZIP) Void.exe rootfs.tar.gz
+	$(TAR) -caf $(OUT_ZIP) Void.exe rootfs.tar.gz
 
 Void.exe: icons.zip
 	@echo -e '\e[1;31mExtracting Void.exe...\e[m'
-	unzip icons.zip Void.exe
+	$(TAR) -xf icons.zip Void.exe
 
 icons.zip:
 	@echo -e '\e[1;31mDownloading icons.zip...\e[m'
@@ -21,12 +23,12 @@ icons.zip:
 
 rootfs.tar.gz: rootfs
 	@echo -e '\e[1;31mBuilding rootfs.tar.gz...\e[m'
-	sudo tar -zcp > rootfs.tar.gz -C rootfs .
+	sudo $(TAR) -czpf - > rootfs.tar.gz -C rootfs .
 
 rootfs: base.tar.xz
 	@echo -e '\e[1;31mBuilding rootfs...\e[m'
 	mkdir rootfs
-	sudo tar -xpmf base.tar.xz -C rootfs
+	sudo $(TAR) -xpmf base.tar.xz -C rootfs
 	sudo cp -f /etc/resolv.conf rootfs/etc/resolv.conf
 	sudo chroot rootfs /sbin/xbps-install --sync --update --yes
 	sudo find rootfs/var/cache/xbps/ -type f -delete

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,18 @@ TAR=bsdtar
 
 OUT_ZIP=Void.zip
 
+# WARNING: the 20191109 snapshot is broken and fails to update:
+#
+# sudo chroot rootfs /sbin/xbps-install --sync --update --yes xbps
+# [*] Updating `https://alpha.de.repo.voidlinux.org/current/x86_64-repodata' ...
+# x86_64-repodata: 1947KB [avg rate: 5979KB/s]
+# libcrypto45-3.0.2_2 (update) breaks installed pkg `libressl-2.9.2_1'
+# libcrypto45-3.0.2_2 (update) breaks installed pkg `libtls19-2.9.2_1'
+# libssl47-3.0.2_2 (update) breaks installed pkg `libressl-2.9.2_1'
+# libssl47-3.0.2_2 (update) breaks installed pkg `libtls19-2.9.2_1'
+# Transaction aborted due to unresolved dependencies.
+# make: *** [Makefile:31: rootfs] Error 19
+
 BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
 
@@ -30,7 +42,8 @@ rootfs: base.tar.xz
 	mkdir rootfs
 	sudo $(TAR) -xpmf base.tar.xz -C rootfs
 	sudo cp -f /etc/resolv.conf rootfs/etc/resolv.conf
-	sudo chroot rootfs /sbin/xbps-install --sync --update --yes
+	sudo chroot rootfs /sbin/xbps-install --sync --update --yes xbps
+	sudo chroot rootfs /sbin/xbps-install --update --yes
 	sudo find rootfs/var/cache/xbps/ -type f -delete
 	sudo rm rootfs/etc/resolv.conf
 	sudo chmod +x rootfs

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,19 @@
 OUT_ZIP=Void.zip
-LNCR_EXE=Void.exe
 
 BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
-LNCR_ZIP_EXE=Void.exe
 
 all: $(OUT_ZIP)
 
 zip: $(OUT_ZIP)
 
-$(OUT_ZIP): $(LNCR_EXE) rootfs.tar.gz
+$(OUT_ZIP): Void.exe rootfs.tar.gz
 	@echo -e '\e[1;31mBuilding $(OUT_ZIP)\e[m'
-	zip $(OUT_ZIP) $(LNCR_EXE) rootfs.tar.gz
+	zip $(OUT_ZIP) Void.exe rootfs.tar.gz
 
-$(LNCR_EXE): Launcher.exe
-	cp Launcher.exe $(LNCR_EXE)
-
-exe: Launcher.exe
-Launcher.exe: icons.zip
-	@echo -e '\e[1;31mExtracting Launcher.exe...\e[m'
-	unzip icons.zip $(LNCR_ZIP_EXE)
-	mv $(LNCR_ZIP_EXE) Launcher.exe
+Void.exe: icons.zip
+	@echo -e '\e[1;31mExtracting Void.exe...\e[m'
+	unzip icons.zip Void.exe
 
 icons.zip:
 	@echo -e '\e[1;31mDownloading icons.zip...\e[m'
@@ -48,7 +41,7 @@ base.tar.xz:
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'
 	rm -f ${OUT_ZIP}
-	rm -f Launcher.exe
+	rm -f Void.exe
 	rm -f icons.zip
 	rm -f rootfs.tar.gz
 	sudo rm -fr rootfs

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rootfs.tar.gz: rootfs
 rootfs: base.tar.xz
 	@echo -e '\e[1;31mBuilding rootfs...\e[m'
 	mkdir rootfs
-	sudo tar -xpf base.tar.xz -C rootfs
+	sudo tar -xpmf base.tar.xz -C rootfs
 	sudo cp -f /etc/resolv.conf rootfs/etc/resolv.conf
 	sudo chroot rootfs /sbin/xbps-install --sync --update --yes
 	sudo find rootfs/var/cache/xbps/ -type f -delete

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ icons.zip:
 
 rootfs.tar.gz: rootfs
 	@echo -e '\e[1;31mBuilding rootfs.tar.gz...\e[m'
-	cd rootfs; sudo tar -zcpf ../rootfs.tar.gz `sudo ls`
-	sudo chown `id -un` rootfs.tar.gz
+	sudo tar -zcp > rootfs.tar.gz -C rootfs .
 
 rootfs: base.tar.xz
 	@echo -e '\e[1;31mBuilding rootfs...\e[m'
@@ -30,7 +29,7 @@ rootfs: base.tar.xz
 	sudo tar -xpf base.tar.xz -C rootfs
 	sudo cp -f /etc/resolv.conf rootfs/etc/resolv.conf
 	sudo chroot rootfs /sbin/xbps-install --sync --update --yes
-	sudo rm -rf `sudo find rootfs/var/cache/xbps/ -type f`
+	sudo find rootfs/var/cache/xbps/ -type f -delete
 	sudo rm rootfs/etc/resolv.conf
 	sudo chmod +x rootfs
 

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ base.tar.xz:
 
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'
-	-rm ${OUT_ZIP}
-	-rm -r ziproot
-	-rm Launcher.exe
-	-rm icons.zip
-	-rm rootfs.tar.gz
-	-sudo rm -r rootfs
-	-rm base.tar.xz
+	rm -f ${OUT_ZIP}
+	rm -fr ziproot
+	rm -f Launcher.exe
+	rm -f icons.zip
+	rm -f rootfs.tar.gz
+	sudo rm -fr rootfs
+	rm -f base.tar.xz

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Usage :
 ## How-to-Build
 VoidWSL can build on GNU/Linux or WSL.
 
-`curl`,`zip`,`unzip`,`tar`(gnu) and `sudo` is required for build.
+`curl`, `bsdtar` and `sudo` are required for build.
 ```shell
 $ make
 ```


### PR DESCRIPTION
This fixes several bugs and shortcomings in the Makefile, like the `clean` target wasn't working, the `rootfs` target didn't work twice in a row, and `xbps-install` is/was prone to fail to do its job, see https://github.com/void-linux/xbps/issues/166.