### PR TITLE
Add aarch64 support and simplify the Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,16 @@ jobs:
         run: sudo rm -rf "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
       - name: Install prerequisites
         run: sudo apt install make curl zip unzip check -qq
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Build
-        run: make
+        run: |
+          sudo make
       - name: Upload artifacts
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
-          artifacts="-a ./VoidGlibc.zip -a ./VoidMusl.zip"
+          artifacts="-a ./void-x86_64.zip -a ./void-x86_64-musl.zip -a ./void-aarch64.zip -a void-aarch64-musl.zip"
           tag_name="${GITHUB_REF#refs/tags/}"
           hub release create $artifacts -m "$tag_name" "$tag_name"
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,104 +1,44 @@
-DLR=curl
-DLR_FLAGS=-L
-
 VOID_REVISION=20221001
 BASE_URL=https://repo-default.voidlinux.org/live/$(VOID_REVISION)
-VOID_GLIBC_ROOTFS=void-x86_64-ROOTFS-$(VOID_REVISION).tar.xz
-VOID_MUSL_ROOTFS=void-x86_64-musl-ROOTFS-$(VOID_REVISION).tar.xz
-VOID_GLIBC_URL=$(BASE_URL)/$(VOID_GLIBC_ROOTFS)
-VOID_MUSL_URL=$(BASE_URL)/$(VOID_MUSL_ROOTFS)
-
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/22020900/icons.zip
-LNCR_ZIP_EXE=Void.exe
 
-define prepare-rootfs =
-@echo -e '\e[1;31mPreparing $@...\e[m'
-mkdir $@
-sudo tar -xpf $< -C $@
-sudo cp -f /etc/resolv.conf $@/etc/resolv.conf
-sudo chroot $@ /sbin/xbps-install --sync --update --yes
-sudo rm -rf `sudo find $@/var/cache/xbps/ -type f`
-sudo rm $@/etc/resolv.conf
-sudo chmod +x $@
-endef
+.PHONY: all clean
 
-define pack-rootfs-tarball =
-@echo -e '\e[1;31mPacking $@...\e[m'
-cd $<; sudo tar -zcpf ../$@ `sudo ls`
-sudo chown `id -un` $@
-endef
+all-x86_64: icons.zip void-x86_64 void-x86_64-musl
+all-aarch64: icons.zip void-aarch64 void-aarch64-musl
 
-define prepare-ziproot =
-@echo -e '\e[1;31mPreparing $@...\e[m'
-mkdir $@
-cp $(word 2,$^) $@/
-cp $< $@/rootfs.tar.gz
-endef
+all: all-x86_64 all-aarch64
 
-define pack-zip =
-@echo -e '\e[1;31mPacking $@\e[m'
-cd $<; zip ../$@ *
-endef
+void-x86_64 void-x86_64-musl void-aarch64 void-aarch64-musl:
+	@echo -e '\e[1;31mDownloading $(BASE_URL)/$@-ROOTFS-$(VOID_REVISION).tar.xz...\e[m'
+	curl -LO $(BASE_URL)/$@-ROOTFS-$(VOID_REVISION).tar.xz
 
-all: zip
+	@echo -e '\e[1;31mPreparing $@.zip...\e[m'
+	@mkdir $@-zip
+	@cp Void.exe $@-zip/$@.exe
 
-.PHONY: all zip exe clean
-zip: VoidGlibc.zip VoidMusl.zip
+	@echo -e '\e[1;31mPreparing $@.tar.gz...\e[m'
+	@mkdir $@
+	tar -xpf $@-ROOTFS-$(VOID_REVISION).tar.xz -C $@
+	cp -f /etc/resolv.conf $@/etc/resolv.conf
+	chroot $@ /sbin/xbps-install --sync --update --yes
+	rm -rf `find $@/var/cache/xbps/ -type f`
+	rm $@/etc/resolv.conf
+	chmod +x $@
 
-VoidGlibc.zip: ziproot-glibc
-	$(pack-zip)
+	@echo -e '\e[1;31mPacking rootfs.tar.gz...\e[m'
+	@cd $@; tar -zcpf ../$@-zip/rootfs.tar.gz `ls`
+	chown `id -un` $@-zip/rootfs.tar.gz
 
-VoidMusl.zip: ziproot-musl
-	$(pack-zip)
-
-ziproot-glibc: rootfs-glibc.tar.gz void-glibc.exe
-	$(prepare-ziproot)
-
-ziproot-musl: rootfs-musl.tar.gz void-musl.exe
-	$(prepare-ziproot)
-
-rootfs-glibc.tar.gz: rootfs-glibc
-	$(pack-rootfs-tarball)
-
-rootfs-musl.tar.gz: rootfs-musl
-	$(pack-rootfs-tarball)
-
-rootfs-glibc: base-glibc.tar.xz
-	$(prepare-rootfs)
-
-rootfs-musl: base-musl.tar.xz
-	$(prepare-rootfs)
-
-base-glibc.tar.xz:
-	@echo -e '\e[1;31mDownloading $@...\e[m'
-	$(DLR) $(DLR_FLAGS) $(VOID_GLIBC_URL) -o $@
-
-base-musl.tar.xz:
-	@echo -e '\e[1;31mDownloading $@...\e[m'
-	$(DLR) $(DLR_FLAGS) $(VOID_MUSL_URL) -o $@
-
-exe: void-glibc.exe void-musl.exe
-$(LNCR_ZIP_EXE): icons.zip
-	@echo -e '\e[1;31mExtracting $@...\e[m'
-	unzip $< $@
-
-void-glibc.exe: $(LNCR_ZIP_EXE)
-	@cp $(LNCR_ZIP_EXE) $@
-
-void-musl.exe: $(LNCR_ZIP_EXE)
-	@cp $(LNCR_ZIP_EXE) $@
+	@echo -e '\e[1;31mPacking $@.zip\e[m'
+	@cd $@-zip; zip ../$@.zip *
 
 icons.zip:
 	@echo -e '\e[1;31mDownloading $@...\e[m'
-	$(DLR) $(DLR_FLAGS) $(LNCR_ZIP_URL) -o $@
+	curl -LO $(LNCR_ZIP_URL)
+	@echo -e '\e[1;31mExtracting $@...\e[m'
+	unzip $@ Void.exe
 
 clean:
 	@echo -e '\e[1;31mCleaning files...\e[m'
-	-rm VoidGlibc.zip VoidMusl.zip
-	-rm -r ziproot-glibc ziproot-musl
-	-rm rootfs-glibc.tar.gz rootfs-musl.tar.gz
-	-sudo rm -r rootfs-glibc rootfs-musl
-	-rm base-glibc.tar.xz base-musl.tar.xz
-	-rm void-glibc.exe void-musl.exe
-	-rm $(LNCR_ZIP_EXE)
-	-rm icons.zip
+	-rm -rf void-* Void.exe icons.zip


### PR DESCRIPTION
There is no need to modularize a simple, sequential, script. We only need additional rule to download icons.zip.